### PR TITLE
docs: zero-to-hero README + docs/ for the browser speech client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,152 @@
 # hivemind-webspeech
 
-send speech from browser to hivemind
+Talk to a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) hub from your
+web browser — no install, no audio drivers, no Python. Open a page, grant
+microphone access, and speak.
 
-performs VAD in browser via [ricky0123/vad](https://www.vad.ricky0123.com/) and sends audio via [HivemindJS](https://github.com/JarbasHiveMind/HiveMind-js) for processing
+The browser captures your microphone, runs voice activity detection (VAD) locally to
+isolate spoken utterances, and streams each one as base64-encoded audio over an
+encrypted WebSocket to the hub using
+[HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js). The hub does
+everything else — speech-to-text, intent matching, skills, and the spoken reply —
+and sends the answer back as text rendered on the page.
 
-online demo [here](https://jarbashivemind.github.io/hivemind-webspeech)
+[Online demo](https://jarbashivemind.github.io/hivemind-webspeech)
 
-![imagem](https://github.com/JarbasHiveMind/hivemind-webspeech/assets/33701864/d3a19394-6bf5-42ca-aa1e-e30e6d9e5b81)
+![screenshot](https://github.com/JarbasHiveMind/hivemind-webspeech/assets/33701864/d3a19394-6bf5-42ca-aa1e-e30e6d9e5b81)
 
-NOTE: your browser will refuse to connect to a non-ssl websocket unless it's 127.0.0.1
+## Where it fits — the satellite spectrum
 
-## Configuration
+HiveMind satellites differ by **where the work happens**. The thinner the client,
+the more the hub does. hivemind-webspeech is a browser variant of the thin end: the
+page does microphone capture and VAD, and the hub does the rest.
 
-Hivemind master needs ovos-dinkum-listener >= 0.0.3a19
+| Client | Runs locally | Runs on the hub |
+|---|---|---|
+| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | nothing (text only) | STT · TTS · intent · skills |
+| **hivemind-webspeech** (this, in-browser) | microphone · VAD | STT · TTS · intent · skills |
+| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | microphone · VAD | STT · TTS · intent · skills |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic · VAD · wake-word | STT · TTS · intent · skills |
+| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic · VAD · wake-word · STT · TTS | intent · skills |
+
+hivemind-webspeech is functionally the browser counterpart of
+[hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite):
+both capture the mic and run VAD locally, then hand the audio to the hub. The
+difference is the runtime — a web page instead of a Python process — and the
+transport library ([HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)
+instead of
+[hivemind-websocket-client](https://github.com/JarbasHiveMind/hivemind-websocket-client)).
+There is no wake-word: speech detection is push-to-talk style, gated by the VAD
+toggle button.
+
+STT, TTS, intent matching, and skills all live on the hub and are owned by the hive
+operator behind access-key authentication — the browser cannot choose the speech
+engine, it only ships audio.
+
+## Prerequisites
+
+- A reachable [HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub.
+- The hub's listener running `ovos-dinkum-listener >= 0.0.3a19` so it can accept
+  audio over the bus.
+- A modern browser with `getUserMedia` (microphone) support. The VAD model
+  (Silero, via `onnxruntime-web`) loads from a CDN, so the page needs network
+  access on first load.
+
+### The TLS rule (read this first)
+
+Browsers refuse to open a **non-SSL** WebSocket from a page served over HTTPS, and
+will only allow plain `ws://` to `127.0.0.1`. In practice this means:
+
+- **Local testing on the same machine** — serve the page over `http://localhost`
+  (or open the file directly) and connect to a hub on `127.0.0.1` over plain `ws://`.
+- **Anything remote** — both the page and the hub's WebSocket must be served over
+  TLS (`https://` page → `wss://` hub). A hub reachable only over plain `ws://`
+  cannot be used from an `https://` page.
+
+## Quickstart
+
+### 1. Pair — issue credentials on the hub
+
+On the machine running HiveMind-core:
 
 ```bash
-$ hivemind-core allow-msg "recognizer_loop:b64_audio"
+hivemind-core add-client
+# → Access Key: <key>   Password: <password>
 ```
+
+The browser form labels the password the **Crypto Key**; it is the same value.
+
+### 2. Allow audio messages on the hub
+
+The hub must be told to accept the audio bus message this client sends:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:b64_audio"
+```
+
+### 3. Open the page
+
+Use the [hosted demo](https://jarbashivemind.github.io/hivemind-webspeech) or serve
+your own copy (see [Build](#build)).
+
+### 4. Connect and speak
+
+1. Fill in **IP**, **Port** (default `5678`), **Access Key**, and **Crypto Key**.
+2. Click **CONNECT**. An alert confirms `Connected to HiveMind!`.
+3. The VAD toggle activates. Click **Start VAD**, then just talk.
+4. Each detected utterance is sent to the hub; the spoken reply appears in the page
+   as `HiveMind says: …`, and the captured audio is listed with a playback control.
+5. Click **Stop VAD** to mute capture.
+
+## Build
+
+There is no Python package and no `package.json`. Runtime dependencies (HiveMind-js,
+`onnxruntime-web`, `@ricky0123/vad-web`, Bulma CSS) load from CDNs declared in
+`src/index.html`. The only build-time tool is `esbuild`, run via `npx`:
+
+```bash
+./build.sh
+```
+
+This bundles `src/*.js` into `dist/` and copies the HTML. Serve `dist/` (or `src/`)
+with any static web server. The hosted demo is published to the repo's `gh-pages`
+branch.
+
+## How it works
+
+1. The page instantiates `JarbasHiveMind` (HiveMind-js) and connects with your
+   credentials over an encrypted WebSocket.
+2. `@ricky0123/vad-web` runs the Silero VAD model in the browser (via
+   `onnxruntime-web`) to detect when you start and stop speaking.
+3. On speech end, the captured samples are encoded to a WAV buffer and base64.
+4. The base64 audio is wrapped in a `recognizer_loop:b64_audio` bus message and sent
+   to the hub.
+5. The hub runs STT → intent → skill → TTS and replies; the client renders the
+   spoken text from the `speak` message it receives.
+
+See [`docs/`](docs/index.md) for the full setup walkthrough, configuration
+reference, the audio pipeline, and troubleshooting.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Browser refuses to connect | Non-TLS WebSocket from an HTTPS page, or remote `ws://`. See [the TLS rule](#the-tls-rule-read-this-first). |
+| `Connected` but no reply | Hub missing `allow-msg "recognizer_loop:b64_audio"`, or listener older than `0.0.3a19`. |
+| VAD button never enables | The VAD model failed to load (no network for the CDN, or microphone permission denied). Check the browser console. |
+| No microphone prompt | The page must be served over `https://` or `http://localhost` for `getUserMedia` to work. |
+
+More in [docs/troubleshooting.md](docs/troubleshooting.md).
+
+## Related
+
+| Project | Role |
+|---|---|
+| [HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) | The hub — runs OVOS, manages satellites, owns STT/TTS. |
+| [HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js) | The browser WebSocket client library this page is built on. |
+| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | The native (Python) equivalent: mic + VAD local, hub does the rest. |
+| [HiveMind-webchat](https://github.com/JarbasHiveMind/HiveMind-webchat) | Browser text chat client (no audio). |
+
+## License
+
+Apache-2.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,130 @@
+# Audio pipeline & architecture
+
+hivemind-webspeech is a static web page that turns the browser into a thin HiveMind
+satellite. It does two things locally — capture the microphone and run voice
+activity detection — and delegates everything else to the hub. This page traces what
+happens on the wire.
+
+## The division of labour
+
+| Stage | Where it runs |
+|---|---|
+| Microphone capture | Browser |
+| Voice activity detection (VAD) | Browser (Silero model via `onnxruntime-web`) |
+| WAV encoding + base64 | Browser |
+| Transport (encrypted WebSocket) | Browser ↔ Hub (HiveMind-js) |
+| Speech-to-text (STT) | Hub |
+| Intent matching + skills | Hub (OVOS) |
+| Text-to-speech (TTS) | Hub |
+| Rendering the reply | Browser |
+
+The browser never runs a speech engine. It ships audio; the hub turns audio into
+meaning and a reply.
+
+## Components
+
+The page (`src/index.html`) loads four runtime dependencies from CDNs:
+
+- **[HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)** — the WebSocket
+  client. Handles the encrypted connection, authentication with the access key and
+  crypto key, and the HiveMind message envelope. The companion `asmcrypto.js` and
+  `webcrypto-shim.js` provide crypto primitives in older browsers.
+- **`onnxruntime-web`** — runs the VAD neural model in the browser.
+- **`@ricky0123/vad-web`** — the VAD wrapper: microphone access, the Silero model,
+  and `onSpeechStart` / `onSpeechEnd` callbacks, plus WAV/base64 utilities.
+- **Bulma** — CSS only.
+
+`src/index.js` wires these together.
+
+## The pipeline, step by step
+
+### 1. Connect
+
+When you click **CONNECT**, the page reads the four form fields and calls:
+
+```js
+hivemind_connection.connect(ip, port, "HivemindWebSpeechV0.1", key, crypto_key)
+```
+
+HiveMind-js opens an encrypted WebSocket to the hub and authenticates. On success,
+`onHiveConnected` fires (`Connected to HiveMind!`). A dropped connection fires
+`onHiveDisconnected` (`Hivemind connection lost...`).
+
+### 2. Detect speech
+
+`vad.MicVAD` runs continuously once **Start VAD** is pressed. It uses the Silero VAD
+model to detect speech boundaries:
+
+- `onSpeechStart` — logged when you begin speaking.
+- `onSpeechEnd(samples)` — fires when you stop, handing back the captured audio
+  samples for just that utterance.
+
+There is **no wake-word**. The VAD toggle button is the gate: while VAD is running,
+every detected utterance is sent.
+
+### 3. Encode
+
+On speech end, the samples are encoded and serialized:
+
+```js
+const wavBuffer = vad.utils.encodeWAV(samples)
+const base64    = vad.utils.arrayBufferToBase64(wavBuffer)
+```
+
+The whole utterance is encoded as a single WAV and base64 string — there is **no
+streaming or chunking**. The captured audio is also added to the on-page list with a
+playback control, so you can hear exactly what was sent.
+
+### 4. Send
+
+The base64 audio is wrapped in an OVOS bus message and sent inside a HiveMind `bus`
+envelope:
+
+```js
+{
+  msg_type: "bus",
+  payload: {
+    type: "recognizer_loop:b64_audio",
+    data: { audio: <base64-wav> },
+    context: {
+      source: "javascript",
+      destination: "HiveMind",
+      platform: "JarbasHivemindJsV0.1"
+    }
+  }
+}
+```
+
+The hub must be configured to accept this message
+(`hivemind-core allow-msg "recognizer_loop:b64_audio"`) and run a listener new
+enough to decode it (`ovos-dinkum-listener >= 0.0.3a19`).
+
+### 5. Hub processing
+
+On the hub, `recognizer_loop:b64_audio` feeds the audio into the OVOS pipeline:
+speech-to-text → intent matching → skill execution → text-to-speech. All of this is
+the hub operator's configuration; the browser has no say in which engines are used.
+
+### 6. Reply
+
+When a skill speaks, the hub emits a `speak` message back over the WebSocket.
+HiveMind-js fires `onMycroftSpeak`, and the page renders the text:
+
+```
+HiveMind says: It's 3:45 PM.
+```
+
+The reply here is **text** — the spoken utterance string — rendered on the page, not
+played as audio.
+
+## Relationship to the native satellite
+
+This is the browser counterpart of
+[hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite),
+which performs the identical mic-capture + VAD + ship-to-hub role as a Python
+process using
+[hivemind-websocket-client](https://github.com/JarbasHiveMind/hivemind-websocket-client).
+The thicker satellites add local stages on top of this base: a wake-word
+([HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay)),
+and finally on-device STT and TTS
+([HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,83 @@
+# Configuration
+
+hivemind-webspeech has no config file. Everything is entered in the page's
+credential form at connect time, and a few requirements must be satisfied on the
+hub. This page covers all of it.
+
+## Credential form
+
+The page presents four fields. They map directly to the
+[HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)
+`connect(host, port, username, accessKey, password)` call.
+
+| Field | Maps to | Default / placeholder | Notes |
+|---|---|---|---|
+| **IP** | `host` | `0.0.0.0` | The hub's address. `127.0.0.1` for same-machine, a LAN IP, or a hostname. |
+| **Port** | `port` | `5678` | The hub's WebSocket port. |
+| **Access Key** | `accessKey` | — | Issued by `hivemind-core add-client`. |
+| **Crypto Key** | `password` | — | The **Password** from `hivemind-core add-client`. Same value, different label. |
+
+The client identifies itself to the hub with the fixed useragent
+`HivemindWebSpeechV0.1`.
+
+## Hub requirements
+
+The hub must be prepared to receive audio:
+
+1. **Listener version** — the hub's listener must run
+   `ovos-dinkum-listener >= 0.0.3a19`, which understands base64 audio over the bus.
+2. **Allowed message** — the hub must permit the audio bus message this client
+   sends:
+
+   ```bash
+   hivemind-core allow-msg "recognizer_loop:b64_audio"
+   ```
+
+   Without this the WebSocket connects but audio is dropped and you get no reply.
+
+STT, TTS, intent, and skills are all configured on the hub, not here. The browser
+cannot choose the speech engine — the operator owns it behind access-key auth.
+
+## The TLS / mixed-content rule
+
+This is the single most common source of "it won't connect" problems.
+
+Browsers enforce mixed-content and secure-context rules on WebSockets:
+
+- A page served over **`https://`** may only open a **`wss://`** (TLS) WebSocket.
+  A plain `ws://` target is blocked.
+- A plain **`ws://`** WebSocket is only permitted to **`127.0.0.1`** (or
+  `localhost`).
+
+What this means in practice:
+
+| Page served from | Hub reachable at | Works? |
+|---|---|---|
+| `http://localhost` or local file | `ws://127.0.0.1:5678` | Yes |
+| `https://…` (e.g. the hosted demo) | `wss://<host>:5678` (TLS hub) | Yes |
+| `https://…` | `ws://<remote-host>:5678` (plain) | **No** — blocked |
+| `http://<lan-ip>` | `ws://<remote-host>` | Browser-dependent; avoid |
+
+To reach a remote hub from the hosted (`https://`) demo, the hub's WebSocket must
+terminate TLS (`wss://`). For purely local experiments, serve the page on
+`localhost` and use plain `ws://` to `127.0.0.1`.
+
+## Network access on first load
+
+`src/index.html` pulls its dependencies from CDNs at runtime:
+
+- [HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js) (WebSocket client +
+  crypto shims)
+- `onnxruntime-web` (runs the VAD model)
+- `@ricky0123/vad-web` (the VAD itself)
+- Bulma CSS (styling)
+
+The page therefore needs network access to load these. Once loaded, the only
+ongoing traffic is the encrypted WebSocket to your hub.
+
+## Microphone permission
+
+Voice capture uses `getUserMedia`, which requires a **secure context**: the page
+must be served over `https://` or from `http://localhost`. Opened any other way, the
+browser will not grant microphone access and the **Start VAD** button will not
+function.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,129 @@
+# Getting Started
+
+This walks you from zero to a working browser voice session against a HiveMind hub.
+
+You need:
+
+- A reachable [HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub,
+  with its listener running `ovos-dinkum-listener >= 0.0.3a19`.
+- A browser with microphone support.
+- Network access on first page load (the VAD model and client libraries load from
+  CDNs).
+
+---
+
+## 1. Pair — get credentials from the hub
+
+Credentials are issued on the **hub** side. On the machine running HiveMind-core:
+
+```bash
+hivemind-core add-client
+```
+
+It prints an **Access Key** and a **Password**. Copy both. In the browser form, the
+Password is entered in the field labelled **Crypto Key** — it is the same value.
+
+---
+
+## 2. Allow the audio message on the hub
+
+By default the hub does not accept audio over the bus. Permit the message this
+client sends:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:b64_audio"
+```
+
+Without this, the connection succeeds but spoken utterances are silently dropped and
+you get no reply.
+
+---
+
+## 3. Open the page
+
+Use the hosted demo:
+
+<https://jarbashivemind.github.io/hivemind-webspeech>
+
+or serve your own copy — see [Build](#building-your-own-copy) below.
+
+> **TLS / mixed-content rule.** A browser will not open a plain `ws://` WebSocket
+> from a page served over `https://`, and only allows `ws://` at all to
+> `127.0.0.1`. So:
+> - **Same machine / local test** — serve the page over `http://localhost` and use
+>   `ws://` to a hub on `127.0.0.1`.
+> - **Remote hub** — both the page (`https://`) and the hub WebSocket (`wss://`)
+>   must use TLS.
+>
+> See [Configuration](configuration.md) for details.
+
+---
+
+## 4. Connect
+
+Fill the form:
+
+| Field | Value |
+|---|---|
+| **IP** | The hub's address (e.g. `127.0.0.1` or `192.168.1.10`) |
+| **Port** | The hub WebSocket port (default `5678`) |
+| **Access Key** | From `hivemind-core add-client` |
+| **Crypto Key** | The Password from `hivemind-core add-client` |
+
+Click **CONNECT**. An alert confirms:
+
+```
+Connected to HiveMind!
+```
+
+If the connection drops later you get `Hivemind connection lost...`.
+
+---
+
+## 5. Speak
+
+After connecting, the **Start VAD** button activates.
+
+1. Click **Start VAD** (the page asks for microphone permission the first time).
+2. Just talk. Voice activity detection runs in the browser and detects when you
+   start and stop speaking — there is no wake-word.
+3. Each detected utterance is sent to the hub. The spoken reply appears as:
+
+   ```
+   HiveMind says: It's 3:45 PM.
+   ```
+
+   and the captured audio is added to the list with a playback control.
+4. Click **Stop VAD** to mute capture.
+
+That's it — you are talking to your hive from the browser.
+
+---
+
+## What just happened
+
+1. The page connected to the hub over an encrypted WebSocket using your access key
+   and crypto key (via [HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)).
+2. The browser ran VAD on your microphone and isolated one utterance.
+3. The utterance was encoded to WAV, base64-ed, and sent as a
+   `recognizer_loop:b64_audio` bus message.
+4. The hub ran STT → intent → skill → TTS and replied; the page rendered the spoken
+   text.
+
+No speech engine ran in your browser — only capture and VAD. See
+[the audio pipeline](architecture.md) for the full picture.
+
+---
+
+## Building your own copy
+
+There is no Python package and no `package.json`. Runtime dependencies load from
+CDNs; the only build tool is `esbuild` via `npx`:
+
+```bash
+./build.sh
+```
+
+This bundles `src/*.js` into `dist/` and copies the HTML. Serve `dist/` (or `src/`)
+with any static web server that satisfies the TLS rule above. The hosted demo is
+published to the repo's `gh-pages` branch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# hivemind-webspeech — Documentation
+
+hivemind-webspeech is a **browser** speech client for
+[HiveMind](https://github.com/JarbasHiveMind/HiveMind-core). It captures your
+microphone, runs voice activity detection (VAD) in the page, and streams each spoken
+utterance as base64 audio to a HiveMind hub over an encrypted WebSocket. The hub
+handles speech-to-text, intent, skills, and the reply.
+
+No install, no Python, no audio drivers — a web page and a microphone.
+
+## The satellite spectrum
+
+HiveMind satellites differ by **where the work happens**. This client sits at the
+thin end (browser variant): microphone capture and VAD run locally, everything else
+runs on the hub.
+
+| Client | Runs locally | Runs on the hub |
+|---|---|---|
+| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | nothing (text only) | STT · TTS · intent · skills |
+| **hivemind-webspeech** ← you are here | microphone · VAD | STT · TTS · intent · skills |
+| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | microphone · VAD | STT · TTS · intent · skills |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic · VAD · wake-word | STT · TTS · intent · skills |
+| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic · VAD · wake-word · STT · TTS | intent · skills |
+
+hivemind-webspeech is the browser counterpart of the native
+[hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite):
+the same division of labour, a web page instead of a Python process, built on
+[HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js) rather than
+[hivemind-websocket-client](https://github.com/JarbasHiveMind/hivemind-websocket-client).
+
+## Documentation pages
+
+| Page | What it covers |
+|---|---|
+| [Getting started](getting-started.md) | Pair, allow the audio message, open the page, speak |
+| [Configuration](configuration.md) | Credential fields, ports, the TLS / mixed-content rule, hub requirements |
+| [Audio pipeline](architecture.md) | How mic → VAD → WAV → base64 → bus → reply works on the wire |
+| [Troubleshooting](troubleshooting.md) | Connection, TLS, audio, and VAD problems |
+
+## Quick reference
+
+```bash
+# on the hub:
+hivemind-core add-client                              # → Access Key + Password
+hivemind-core allow-msg "recognizer_loop:b64_audio"   # permit audio over the bus
+```
+
+Then open the [demo](https://jarbashivemind.github.io/hivemind-webspeech) (or your
+own build), enter IP / port / access key / crypto key, click **CONNECT**, then
+**Start VAD**, and speak.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,92 @@
+# Troubleshooting
+
+Symptoms grouped by stage: connection, audio capture, and the reply. Open the
+browser developer console (F12) first — `src/index.js` logs each stage there.
+
+## Connection
+
+### The browser refuses to connect / WebSocket error in the console
+
+Almost always the TLS / mixed-content rule. Browsers block a plain `ws://`
+WebSocket from an `https://` page, and only allow `ws://` at all to `127.0.0.1`.
+
+- From the hosted (`https://`) demo, the hub must be reachable over **`wss://`**
+  (TLS). A plain-`ws://` hub cannot be used.
+- For local testing, serve the page over `http://localhost` and connect to a hub on
+  `ws://127.0.0.1`.
+
+See [Configuration → the TLS rule](configuration.md#the-tls--mixed-content-rule).
+
+### "Hivemind connection lost..."
+
+The WebSocket dropped after connecting. Check:
+
+- The hub is still running and reachable at the IP/port you entered.
+- The **Access Key** and **Crypto Key** are correct and the key has not been
+  revoked on the hub (`hivemind-core` client management).
+- Firewall/NAT between you and the hub.
+
+### Connect succeeds but nothing happens when you speak
+
+The connection is fine but the hub is dropping the audio message. Confirm on the
+hub:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:b64_audio"
+```
+
+and that the listener is `ovos-dinkum-listener >= 0.0.3a19`. Without both, audio
+arrives and is discarded.
+
+## Audio capture / VAD
+
+### The "Start VAD" button never enables (stays loading)
+
+The VAD failed to initialize. Causes:
+
+- **No network on first load** — the VAD model and `onnxruntime-web` load from a
+  CDN. Check the console for failed CDN requests.
+- **Microphone permission denied** — grant it and reload.
+- **Insecure context** — `getUserMedia` only works over `https://` or
+  `http://localhost`. Opened any other way, the mic is unavailable.
+
+### No microphone permission prompt appears
+
+The page is not in a secure context. Serve it over `https://` or
+`http://localhost`.
+
+### VAD runs but utterances are never sent
+
+Open the console. You should see `Speech start` / `Speech end` logs when you talk.
+If they do not appear, the VAD is not hearing you — check the OS/browser microphone
+selection and input level. If they do appear but no reply comes, the problem is on
+the hub side (see "Connect succeeds but nothing happens" above).
+
+### Audio is cut off or split oddly
+
+The VAD decides utterance boundaries; very short pauses can split a sentence into two
+sends, and background noise can trigger spurious sends. Each send is listed with a
+playback control — play it back to hear exactly what was captured.
+
+## Reply
+
+### I speak, the audio is listed, but no "HiveMind says:" text appears
+
+The audio reached the page's list (so capture/encode worked) but no `speak` came
+back. This is a hub-side issue:
+
+- The audio message may be blocked — re-check `allow-msg`.
+- STT on the hub may have produced no transcript (silence, noise, wrong language).
+- The intent may not have matched any skill, so nothing spoke.
+
+Inspect the hub logs to see whether the utterance was transcribed and which skill
+(if any) handled it.
+
+## Still stuck
+
+- Confirm the hosted demo works against a known-good `wss://` hub first to isolate
+  whether the problem is the page or your hub.
+- Cross-check the hub setup against
+  [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite)
+  — it sends the same `recognizer_loop:b64_audio` message and has the same hub
+  requirements, so a working mic-satellite confirms the hub side is correct.


### PR DESCRIPTION
Brings the README and a new `docs/` set to zero-to-hero quality.

## What changed
- **README** rewritten: tagline, the **satellite-spectrum** framing (browser counterpart of `hivemind-mic-satellite` — mic + VAD local, hub does STT/TTS/intent/skills), prerequisites incl. the TLS/mixed-content rule, hub pairing + `allow-msg` quickstart, build, how-it-works, troubleshooting table, related links.
- **docs/index.md** — doc hub + spectrum table.
- **docs/getting-started.md** — pair, allow the audio message, open the page, connect, speak.
- **docs/configuration.md** — credential-field mapping, hub requirements, the TLS rule, secure-context/mic notes.
- **docs/architecture.md** — the audio pipeline: mic → VAD → WAV → base64 → `recognizer_loop:b64_audio` bus message → hub → `speak` reply.
- **docs/troubleshooting.md** — connection, TLS, VAD, and reply problems.

Docs-only; no code, tests, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)