### PR TITLE
ci: install hivescope from its PyPI release in the e2e (drop --pre + git-branch pin)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,13 +40,11 @@ jobs:
           python -m venv /tmp/e2e-venv
           /tmp/e2e-venv/bin/python -m pip install --upgrade pip
           # hivescope provides the loopback hivemind-core hub the test drives.
-          # The loopback whitelist fix is not yet on a published release, so we
-          # install from the git branch carrying it.
-          # --pre: the HiveMind 2.x stack (hivemind-core 4.6.x / hivemind-bus-client
-          # 0.9.x on ovos-bus-client 2.x) is prerelease-only on PyPI; without it
-          # pip resolves old stable core and the hub's ACL/admission differs.
-          /tmp/e2e-venv/bin/python -m pip install --pre \
-            "hivescope @ git+https://github.com/JarbasHiveMind/hivescope.git@fix/loopback-whitelist-only-connection"
+          # hivescope >=0.5.2a1 floors the whole HiveMind 2.x stack itself
+          # (hivemind-core>=4.6.2a1, hivemind-bus-client>=0.9.2a1,
+          # ovos-bus-client>=2.0.0a3) with prerelease specifiers, so a plain
+          # min-pin resolves the right stack — no --pre needed.
+          /tmp/e2e-venv/bin/python -m pip install "hivescope>=0.5.2a1"
 
       - name: Run E2E (V1 client ↔ real loopback hub)
         env:

--- a/README.md
+++ b/README.md
@@ -128,8 +128,16 @@ real loopback `hivemind-core` hub: it performs the full password handshake, send
 AES-GCM-encrypted utterance, and asserts the hub decrypted and received it.
 
 ```bash
-npm ci
-npm test
+# Node side: the `ws` WebSocket polyfill used to run the browser client headless.
+npm install
+
+# Python side: a venv with the loopback hub. hivescope floors the whole
+# HiveMind 2.x stack itself, so a plain min-pin pulls the right packages.
+python -m venv .venv
+.venv/bin/python -m pip install "hivescope>=0.5.2a1"
+
+# Run, pointing the test at that venv.
+E2E_PYTHON=.venv/bin/python npm test
 ```
 
 The test (`tests/e2e.test.mjs`, Node's built-in runner) spawns a Python loopback hub

--- a/tests/loopback_hub.py
+++ b/tests/loopback_hub.py
@@ -17,8 +17,9 @@ utterance end to end.
 Usage:
     loopback_hub.py <sat_key> <sat_password> <expected_utterance>
 
-Requires the hivemind-e2e venv (hivescope editable, with the loopback fix):
-    ~/.venvs/hivemind-e2e/bin/python tests/loopback_hub.py ...
+Requires a venv with hivescope (which floors the HiveMind 2.x stack):
+    python -m pip install "hivescope>=0.5.2a1"
+    /path/to/venv/bin/python tests/loopback_hub.py ...
 """
 import sys
 


### PR DESCRIPTION
## Why

The e2e loopback hub installed hivescope from a feature branch
(`fix/loopback-whitelist-only-connection`) under `pip install --pre`. That
branch no longer exists — its work shipped in **hivescope 0.5.2a1** — so the
CI install is now broken. Forcing prereleases with `--pre` also violates the
org floor-pin rule (depend on a prerelease by min-pinning it, never `--pre`).

## What

- **`.github/workflows/e2e.yml`** — install `hivescope>=0.5.2a1` from PyPI; drop
  `--pre` and the git-branch ref. hivescope >=0.5.2a1 already floors the whole
  HiveMind 2.x stack with prerelease specifiers (`hivemind-core>=4.6.2a1`,
  `hivemind-bus-client>=0.9.2a1`, `ovos-bus-client>=2.0.0a3`), so a plain
  min-pin resolves the right stack with **no `--pre`**.
- **`README.md`** — Tests section now gives runnable instructions (`npm install`
  + a hivescope venv + `E2E_PYTHON`). Drops `npm ci`, which requires a lockfile
  this repo intentionally gitignores.
- **`tests/loopback_hub.py`** — docstring points at the released package.

## E2E verification (real hub, hermetic)

Ran the e2e locally against a venv built exactly as CI now does it
(`pip install "hivescope>=0.5.2a1"`, no `--pre`) with the dev HiveMind-js client
and Node 22 + `ws`. The resolved stack: hivemind-core 4.6.7a1,
hivemind-bus-client 0.9.2a1, ovos-bus-client 2.3.0a1. The test spawns the
real loopback `hivemind-core` hub, the V1 client completes the
PBKDF2 password handshake, and an AES-GCM-encrypted utterance crosses the wire
and is decrypted onto the hub bus — all on 127.0.0.1, no external network:

```
# HiveMind: HANDSHAKE response received
# HiveMind: key derived, size: 256 bit
# HiveMind: HELLO sent — Connected
ok 1 - V1 client handshake + encrypted utterance reaches a real hub
# pass 1
# fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)