### PR TITLE
feat: configurable in-browser wake word, audio transport, and TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ page does microphone capture and VAD, and hivemind-core does the rest.
 | Client | Runs locally | Runs on hivemind-core |
 |---|---|---|
 | [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | nothing (text only) | STT · TTS · intent · skills |
-| **hivemind-webspeech** (this, in-browser) | microphone · VAD | STT · TTS · intent · skills |
+| **hivemind-webspeech** (this, in-browser) | microphone · VAD · (optional wake-word · TTS) | STT · intent · skills · (TTS) |
 | [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | microphone · VAD | STT · TTS · intent · skills |
 | [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic · VAD · wake-word | STT · TTS · intent · skills |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic · VAD · wake-word · STT · TTS | intent · skills |
@@ -70,12 +70,32 @@ difference is the runtime — a web page instead of a Python process — and the
 transport library ([HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)
 instead of
 [hivemind-websocket-client](https://github.com/JarbasHiveMind/hivemind-websocket-client)).
-There is no wake-word: speech detection is push-to-talk style, gated by the VAD
-toggle button.
+By default speech detection is push-to-talk style, gated by the VAD toggle
+button, and hivemind-core does all speech work. The [Settings](#client-side-options)
+panel can optionally move a wake word and text-to-speech into the browser.
 
-STT, TTS, intent matching, and skills all live on hivemind-core and are owned by the hive
+STT, intent matching, and skills always live on hivemind-core and are owned by the
 operator behind access-key authentication — the browser cannot choose the speech
-engine, it only ships audio.
+engine, it only ships audio (and, optionally, speaks the reply locally).
+
+## Client-side options
+
+Three independent options in the page's **Settings** panel control where work
+happens. Each is saved in the browser and **defaults to the base behaviour**, so
+an untouched page acts exactly as the minimal client — nothing regresses.
+
+| Option | Default | Alternative | What the alternative does |
+|---|---|---|---|
+| **Wake word** | `off` | `precise-onnx-js` | Runs a [Precise](https://github.com/MycroftAI/mycroft-precise) `.onnx` wake word in the browser via [precise-onnx-js](https://github.com/TigreGotico/precise-onnx-js) and gates capture — audio is streamed only after the wake word fires. |
+| **Audio transport** | `base64` | `binary` | Sends each utterance as a WIRE-1 `STT_AUDIO_HANDLE` raw-PCM binary frame instead of a base64 WAV bus message — smaller and faster on the wire. Falls back to `base64` automatically when the session cannot carry binary frames. |
+| **Text to speech** | `server-text` | `phoonnx-js` | Synthesizes the spoken reply in the browser with [phoonnx.js](https://github.com/TigreGotico/phoonnx.js) and plays it, in addition to showing the text. A voice selector picks the model. |
+
+The wake-word and TTS libraries are fetched only when their option is enabled, so
+the default page loads nothing extra. The wake-word model is referenced by URL (a
+hosted `hey_mycroft` model by default — no weights are committed here) and the
+phoonnx voice by id. See [docs/configuration.md](docs/configuration.md#settings-panel)
+for the full option reference, model/voice hosting, and the transport and
+build notes.
 
 ## Prerequisites
 
@@ -197,7 +217,12 @@ hivemind-core automatically — see [`.github/workflows/e2e.yml`](.github/workfl
 4. The base64 audio is wrapped in a `recognizer_loop:b64_audio` bus message and sent
    to hivemind-core.
 5. hivemind-core runs STT → intent → skill → TTS and replies; the client renders the
-   spoken text from the `speak` message it receives.
+   spoken text from the `speak` message it receives, and — with the `phoonnx-js`
+   TTS option — also synthesizes and plays that text in the browser.
+
+The [Settings](#client-side-options) panel can move the wake word into the
+browser (step 2 gates capture behind it) and switch step 4 to raw-PCM binary
+frames.
 
 See [`docs/`](docs/index.md) for the full setup walkthrough, configuration
 reference, the audio pipeline, and troubleshooting.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,9 @@
 # Configuration
 
-hivemind-webspeech has no config file. Everything is entered in the page's
-credential form at connect time, and a few requirements must be satisfied on the
-hub. This page covers all of it.
+hivemind-webspeech has no config file. Connection details are entered in the
+page's credential form at connect time; behavioural options are chosen in the
+page's **Settings** panel and saved in the browser; and a few requirements must
+be satisfied on hivemind-core. This page covers all of it.
 
 ## Credential form
 
@@ -12,21 +13,64 @@ The page presents four fields. They map directly to the
 
 | Field | Maps to | Default / placeholder | Notes |
 |---|---|---|---|
-| **IP** | `host` | `0.0.0.0` | The hub's address. `127.0.0.1` for same-machine, a LAN IP, or a hostname. |
-| **Port** | `port` | `5678` | The hub's WebSocket port. |
+| **IP** | `host` | `0.0.0.0` | hivemind-core's address. `127.0.0.1` for same-machine, a LAN IP, or a hostname. |
+| **Port** | `port` | `5678` | hivemind-core's WebSocket port. |
 | **Access Key** | `accessKey` | — | Issued by `hivemind-core add-client`. |
 | **Password** | `password` | — | The **Password** from `hivemind-core add-client`. The V1 client derives the AES-GCM session key from it during the handshake. |
 
-The client identifies itself to the hub with the fixed useragent
+The client identifies itself to hivemind-core with the fixed useragent
 `HivemindWebSpeechV0.2`.
 
-## Hub requirements
+## Settings panel
 
-The hub must be prepared to receive audio:
+The **Settings** section of the page exposes three independent options, each
+persisted in `localStorage` under `hivemind-webspeech.settings`. Every option
+defaults to the value that reproduces the base behaviour, so a browser with no
+saved settings behaves exactly as the minimal client does.
 
-1. **Listener version** — the hub's listener must run
+| Option | Values | Default | Effect |
+|---|---|---|---|
+| **Wake word** | `off`, `precise-onnx-js` | `off` | `off` streams every VAD-segmented utterance. `precise-onnx-js` loads a [Precise](https://github.com/MycroftAI/mycroft-precise) `.onnx` model in the browser and gates capture: nothing is streamed until the wake word fires, then the following utterance is sent. |
+| **Audio transport** | `base64`, `binary` | `base64` | `base64` sends each utterance as a base64 WAV `recognizer_loop:b64_audio` bus message. `binary` sends it as a WIRE-1 `STT_AUDIO_HANDLE` raw-PCM binary frame — smaller on the wire, no base64 inflation. |
+| **Text to speech** | `server-text`, `phoonnx-js` | `server-text` | `server-text` renders the spoken reply as text. `phoonnx-js` also synthesizes the reply text in the browser with [phoonnx.js](https://github.com/TigreGotico/phoonnx.js) and plays it. |
+
+Two text fields tune the non-default modes:
+
+- **Wake-word model URL** — any Precise `.onnx` model URL. The default points at a
+  hosted `hey_mycroft` model, so no weights are committed to this repository. Host
+  your own model anywhere the browser can fetch it (respecting CORS).
+- **phoonnx voice id** — a voice id from the phoonnx.js voice registry (for
+  example `phoonnx_en-US_miro_unicode` or a piper/Home-Assistant-compatible
+  espeak voice). The model is downloaded from HuggingFace and cached by the
+  browser on first use.
+
+### How each mode loads its library
+
+The wake-word and TTS libraries are fetched **only** when their mode is enabled,
+so the default page loads nothing extra:
+
+- **precise-onnx-js** — its browser scripts (`mfcc.js`, then `wakeword.js`) are
+  injected from jsDelivr and reuse the `onnxruntime-web` runtime already loaded
+  for the VAD.
+- **phoonnx.js** — imported on demand as an ES module from `esm.sh`, which builds
+  the package from source. For a fully self-contained deployment, bundle
+  phoonnx.js into `dist/` with your own build step instead of importing it at
+  runtime.
+
+### Transport requirements
+
+The `binary` transport needs a session that carries binary frames: a protocol-v3
+(Noise) session, or a v1 session where hivemind-core negotiated binarization.
+When neither is available the client automatically falls back to `base64` for
+that utterance, so audio always flows.
+
+## hivemind-core requirements
+
+hivemind-core must be prepared to receive audio:
+
+1. **Listener version** — hivemind-core's listener must run
    `ovos-dinkum-listener >= 0.0.3a19`, which understands base64 audio over the bus.
-2. **Allowed message** — the hub must permit the audio bus message this client
+2. **Allowed message** — hivemind-core must permit the audio bus message this client
    sends:
 
    ```bash
@@ -34,8 +78,11 @@ The hub must be prepared to receive audio:
    ```
 
    Without this the WebSocket connects but audio is dropped and you get no reply.
+   The `binary` transport instead uses hivemind-core's WIRE-1 `STT_AUDIO_HANDLE`
+   binary handler, which is admitted by hivemind-core's binary policy rather than
+   the bus allow-list.
 
-STT, TTS, intent, and skills are all configured on the hub, not here. The browser
+STT, TTS, intent, and skills are all configured on hivemind-core, not here. The browser
 cannot choose the speech engine — the operator owns it behind access-key auth.
 
 ## The TLS / mixed-content rule
@@ -51,14 +98,14 @@ Browsers enforce mixed-content and secure-context rules on WebSockets:
 
 What this means in practice:
 
-| Page served from | Hub reachable at | Works? |
+| Page served from | hivemind-core reachable at | Works? |
 |---|---|---|
 | `http://localhost` or local file | `ws://127.0.0.1:5678` | Yes |
-| `https://…` (e.g. the hosted demo) | `wss://<host>:5678` (TLS hub) | Yes |
-| `https://…` | `ws://<remote-host>:5678` (plain) | **No** — blocked |
+| `https://…` (e.g. the hosted demo) | `wss://<host>:5678` (TLS hivemind-core) | Yes |
+| `https://…` | `ws://<remote-host>:5678` (plain ws://) | **No** — blocked |
 | `http://<lan-ip>` | `ws://<remote-host>` | Browser-dependent; avoid |
 
-To reach a remote hub from the hosted (`https://`) demo, the hub's WebSocket must
+To reach a remote hivemind-core instance from the hosted (`https://`) demo, hivemind-core's WebSocket must
 terminate TLS (`wss://`). For purely local experiments, serve the page on
 `localhost` and use plain `ws://` to `127.0.0.1`.
 
@@ -72,8 +119,13 @@ terminate TLS (`wss://`). For purely local experiments, serve the page on
 - `@ricky0123/vad-web` (the VAD itself)
 - Bulma CSS (styling)
 
+When the matching Settings option is enabled, two further libraries load on
+demand: [precise-onnx-js](https://github.com/TigreGotico/precise-onnx-js) (wake
+word) and [phoonnx.js](https://github.com/TigreGotico/phoonnx.js) (in-browser
+TTS). Under the default settings neither is fetched.
+
 The page therefore needs network access to load these. Once loaded, the only
-ongoing traffic is the encrypted WebSocket to your hub.
+ongoing traffic is the encrypted WebSocket to your hivemind-core instance.
 
 ## Microphone permission
 

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,93 @@
+// Audio helpers and the capture state machine shared by src/index.js.
+//
+// Everything here is DOM-free and network-free: the browser-only pieces (wake
+// word model, phoonnx voice, HiveMind-js socket) are injected as callables so
+// the routing/gating/encoding logic can be unit tested under Node.
+
+import { BIN_TYPES_FALLBACK } from './constants.js';
+
+// Convert normalized float32 PCM ([-1, 1], as produced by the VAD) to 16-bit
+// little-endian PCM bytes — the raw audio hivemind-core's binary STT handlers
+// wrap in a speech_recognition AudioData (sample_width = 2).
+export function floatTo16BitPCM(float32) {
+  const out = new Uint8Array(float32.length * 2);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < float32.length; i++) {
+    let s = float32[i];
+    if (s > 1) s = 1;
+    else if (s < -1) s = -1;
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return out;
+}
+
+// Build the WIRE-1 binary frame (bitstring) for one complete utterance, ready to
+// be encrypted and sent. `encodeBitstring` and `binTypes` come from HiveMind-js
+// (globalThis) so this stays a pure function.
+export function encodeAudioBinaryFrame(encodeBitstring, binTypes, pcmBytes, meta) {
+  const types = binTypes || BIN_TYPES_FALLBACK;
+  const metadata = Object.assign(
+    { sample_rate: 16000, sample_width: 2 },
+    meta || {}
+  );
+  return encodeBitstring('bin', pcmBytes, metadata, types.STT_AUDIO_HANDLE);
+}
+
+// Gate that decides, per VAD-segmented utterance, whether it should be streamed.
+//
+//   'off'             -> every utterance is sent.
+//   'precise-onnx-js' -> the gate stays disarmed until the wake word fires
+//                        inside an utterance; the utterance that trips it is
+//                        swallowed, and the NEXT utterance is streamed, after
+//                        which the gate disarms again.
+//
+// `detect` is an async (Float32Array) => boolean that reports whether the wake
+// word fired somewhere in the utterance. It is only consulted while disarmed.
+export class CaptureGate {
+  constructor(mode, detect) {
+    this.mode = mode;
+    this.detect = detect;
+    this.armed = false;
+  }
+
+  reset() {
+    this.armed = false;
+  }
+
+  // Returns { send, armed } for a completed utterance.
+  async consider(float32) {
+    if (this.mode !== 'precise-onnx-js') {
+      return { send: true, armed: false };
+    }
+    if (this.armed) {
+      this.armed = false;
+      return { send: true, armed: false };
+    }
+    let fired = false;
+    try {
+      fired = await this.detect(float32);
+    } catch (_) {
+      fired = false;
+    }
+    this.armed = !!fired;
+    return { send: false, armed: this.armed };
+  }
+}
+
+// Feed a whole utterance to a streaming Precise detector in fixed-size chunks,
+// reporting whether it fired at any point. `detector.predict(chunk)` follows the
+// precise-onnx-js API (2048-sample Float32Array chunks, returns boolean).
+export async function detectWakeWordInUtterance(detector, float32, chunkSize = 2048) {
+  if (typeof detector.clear === 'function') detector.clear();
+  let fired = false;
+  for (let off = 0; off < float32.length; off += chunkSize) {
+    let chunk = float32.subarray(off, off + chunkSize);
+    if (chunk.length < chunkSize) {
+      const padded = new Float32Array(chunkSize);
+      padded.set(chunk);
+      chunk = padded;
+    }
+    if (await detector.predict(chunk)) fired = true;
+  }
+  return fired;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,98 @@
+// Client-side settings for hivemind-webspeech.
+//
+// Three independent axes decide how the browser behaves, each defaulting to the
+// original streaming behaviour so a page with no saved settings acts exactly as
+// before:
+//
+//   wakeWord  — 'off'            : every VAD-segmented utterance is streamed
+//               'precise-onnx-js': capture is gated behind an in-browser wake
+//                                  word; audio is only streamed once it fires
+//   transport — 'base64'         : utterances are sent as base64 WAV in a
+//                                  recognizer_loop:b64_audio bus message
+//               'binary'         : utterances are sent as raw-PCM WIRE-1 binary
+//                                  frames (STT_AUDIO_HANDLE), smaller on the wire
+//   tts       — 'server-text'    : the spoken reply is shown as text
+//               'phoonnx-js'     : the reply text is synthesized in-browser and
+//                                  played back
+//
+// The module is DOM-free and side-effect-free so it can be unit tested under
+// Node with a plain object as the storage backend.
+
+export const WAKE_WORD_MODES = ['off', 'precise-onnx-js'];
+export const TRANSPORT_MODES = ['base64', 'binary'];
+export const TTS_MODES = ['server-text', 'phoonnx-js'];
+
+// A hosted precise-lite wake-word model. Any Precise `.onnx` URL works; this one
+// is served from jsDelivr so the page needs no committed weights.
+export const DEFAULT_PRECISE_MODEL_URL =
+  'https://cdn.jsdelivr.net/gh/OpenVoiceOS/precise-lite-models@master/wakewords/hey_mycroft/hey_mycroft.onnx';
+
+// A phoonnx voice id (see the phoonnx.js voice registry). Piper / Home-Assistant
+// compatible espeak voices and unicode voices are both valid.
+export const DEFAULT_PHOONNX_VOICE = 'phoonnx_en-US_miro_unicode';
+
+export const DEFAULTS = Object.freeze({
+  wakeWord: 'off',
+  transport: 'base64',
+  tts: 'server-text',
+  preciseModelUrl: DEFAULT_PRECISE_MODEL_URL,
+  phoonnxVoice: DEFAULT_PHOONNX_VOICE,
+});
+
+const STORAGE_KEY = 'hivemind-webspeech.settings';
+
+function pickEnum(value, allowed, fallback) {
+  return allowed.indexOf(value) !== -1 ? value : fallback;
+}
+
+function pickString(value, fallback) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+// Coerce an arbitrary (possibly partial or hostile) object into a valid config,
+// filling every field from DEFAULTS. Never throws.
+export function normalizeConfig(partial) {
+  const p = partial && typeof partial === 'object' ? partial : {};
+  return {
+    wakeWord: pickEnum(p.wakeWord, WAKE_WORD_MODES, DEFAULTS.wakeWord),
+    transport: pickEnum(p.transport, TRANSPORT_MODES, DEFAULTS.transport),
+    tts: pickEnum(p.tts, TTS_MODES, DEFAULTS.tts),
+    preciseModelUrl: pickString(p.preciseModelUrl, DEFAULTS.preciseModelUrl),
+    phoonnxVoice: pickString(p.phoonnxVoice, DEFAULTS.phoonnxVoice),
+  };
+}
+
+// Read the saved config from a Storage-like backend (localStorage or any object
+// exposing getItem). Returns the defaults when nothing is stored or the stored
+// value is unparseable.
+export function loadConfig(storage) {
+  if (!storage || typeof storage.getItem !== 'function') return normalizeConfig();
+  let raw;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch (_) {
+    return normalizeConfig();
+  }
+  if (!raw) return normalizeConfig();
+  try {
+    return normalizeConfig(JSON.parse(raw));
+  } catch (_) {
+    return normalizeConfig();
+  }
+}
+
+// Persist a config (after normalizing it) to a Storage-like backend. Returns the
+// normalized config that was written.
+export function saveConfig(storage, config) {
+  const normalized = normalizeConfig(config);
+  if (storage && typeof storage.setItem === 'function') {
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+    } catch (_) {
+      /* storage full or unavailable — the in-memory config still applies */
+    }
+  }
+  return normalized;
+}
+
+export { STORAGE_KEY };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,13 @@
+// HiveMind-js exposes BIN_TYPES on globalThis when loaded via <script>. This
+// mirror is used only as a fallback when that global is unavailable (eg. in a
+// unit test that has not loaded the client), keeping the WIRE-1 binary sub-type
+// values in one place.
+export const BIN_TYPES_FALLBACK = Object.freeze({
+  UNDEFINED: 0,
+  RAW_AUDIO: 1,
+  NUMPY_IMAGE: 2,
+  FILE: 3,
+  STT_AUDIO_TRANSCRIBE: 4,
+  STT_AUDIO_HANDLE: 5,
+  TTS_AUDIO: 6,
+});

--- a/src/index.html
+++ b/src/index.html
@@ -63,6 +63,47 @@
 
         <br><br>
 
+        <details>
+            <summary>Settings — wake word, transport, TTS</summary>
+            <small>
+                Three independent options, saved in your browser. Each defaults to
+                the original behaviour, so leaving them untouched changes nothing.
+            </small>
+            <br><br>
+            <form onsubmit="return false">
+                Wake word:
+                <select id="cfgWakeWord">
+                    <option value="off">off — stream every utterance (VAD / push-to-talk)</option>
+                    <option value="precise-onnx-js">precise-onnx-js — gate capture behind an in-browser wake word</option>
+                </select>
+                <br>
+                Wake-word model URL:
+                <input id="cfgPreciseModel" autocomplete="off" type="text" size="60"
+                       placeholder="Precise .onnx model URL"><br>
+
+                Audio transport:
+                <select id="cfgTransport">
+                    <option value="base64">base64 — recognizer_loop:b64_audio bus message</option>
+                    <option value="binary">binary — WIRE-1 raw-PCM audio frames (smaller)</option>
+                </select>
+                <br>
+
+                Text to speech:
+                <select id="cfgTts">
+                    <option value="server-text">server-text — show the reply as text</option>
+                    <option value="phoonnx-js">phoonnx-js — synthesize the reply in-browser and play it</option>
+                </select>
+                <br>
+                phoonnx voice id:
+                <input id="cfgPhoonnxVoice" autocomplete="off" type="text" size="40"
+                       placeholder="phoonnx voice id"><br>
+
+                <button onclick="window.onSaveSettings();" id="saveSettings">SAVE SETTINGS</button>
+            </form>
+        </details>
+
+        <br>
+
 
         <p>Just speak and HiveMind will answer</p>
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,117 +1,294 @@
 // @ts-nocheck
+//
+// hivemind-webspeech browser glue. Three independent, persisted options decide
+// behaviour (see src/config.js); each defaults to the original behaviour:
+//   - wake word : off (VAD push-to-talk) | precise-onnx-js (in-browser gating)
+//   - transport : base64 bus message     | binary WIRE-1 audio frames
+//   - tts       : server reply as text   | phoonnx.js in-browser synthesis
+//
+// The DOM-free logic (config, PCM encoding, capture gating) lives in the sibling
+// modules and is unit tested; this file wires it to the page, the microphone,
+// and the HiveMind-js client.
 
+import { loadConfig, saveConfig, WAKE_WORD_MODES, TRANSPORT_MODES, TTS_MODES } from './config.js';
+import {
+  floatTo16BitPCM,
+  encodeAudioBinaryFrame,
+  CaptureGate,
+  detectWakeWordInUtterance,
+} from './audio.js';
+
+// ── Library CDN locations (loaded lazily, only when the matching mode is on) ───
+// precise-onnx-js ships plain browser scripts that export globals; phoonnx.js is
+// an ESM package built on demand by esm.sh. Neither is fetched under the default
+// settings, so the default page is unchanged.
+const PRECISE_MFCC_URL = 'https://cdn.jsdelivr.net/gh/TigreGotico/precise-onnx-js@main/src/mfcc.js';
+const PRECISE_WW_URL = 'https://cdn.jsdelivr.net/gh/TigreGotico/precise-onnx-js@main/src/wakeword.js';
+const PHOONNX_ESM_URL = 'https://esm.sh/gh/TigreGotico/phoonnx.js';
+const PHOONNX_VOICES_ESM_URL = 'https://esm.sh/gh/TigreGotico/phoonnx.js/voices';
+
+let config = loadConfig(globalThis.localStorage);
 
 function getToggleButton() {
-  return document.getElementById("toggleVAD")
+  return document.getElementById('toggleVAD');
 }
 
+function logLine(text) {
+  const speechList = document.getElementById('audio-list');
+  if (!speechList) return;
+  const entry = document.createElement('p');
+  entry.textContent = text;
+  speechList.prepend(entry);
+}
 
-// HiveMind-js client (hivemind-js dev, protocol v0-v3). The handshake, AES-GCM
-// encryption, and the recognizer_loop:b64_audio bus message are all handled by
-// the client itself via the native sendAudioB64() convenience method. The
-// client negotiates the highest protocol version both peers support (WIRE-1),
-// falling back to the legacy v1 password handshake against older hubs.
-const hivemind_connection = new JarbasHiveMind()
-
+// ── HiveMind-js client ────────────────────────────────────────────────────────
+// The handshake, encryption, and the recognizer_loop:b64_audio bus message are
+// handled by the client; it negotiates the highest protocol version both peers
+// support (WIRE-1) and falls back to the legacy v1 handshake against older
+// hivemind-core instances.
+const hivemind_connection = new JarbasHiveMind();
 
 hivemind_connection.onHiveConnected = function () {
-    window.alert("Connected to HiveMind!")
+  window.alert('Connected to HiveMind!');
 };
 
 hivemind_connection.onMycroftSpeak = function (mycroft_message) {
-    let utterance = mycroft_message.data.utterance;
-    const speechList = document.getElementById("audio-list")
-    const entry = document.createElement("p")
-    entry.textContent = "HiveMind says: " + utterance
-    speechList.prepend(entry)
-}
-
-hivemind_connection.onHiveDisconnected = function () {
-    window.alert("Hivemind connection lost...")
+  const utterance = mycroft_message.data.utterance;
+  logLine('HiveMind says: ' + utterance);
+  if (config.tts === 'phoonnx-js' && utterance) {
+    speakWithPhoonnx(utterance).catch((e) => console.error('phoonnx TTS failed:', e));
+  }
 };
 
+hivemind_connection.onHiveDisconnected = function () {
+  window.alert('Hivemind connection lost...');
+};
 
-window.hivemind_connection = hivemind_connection
+window.hivemind_connection = hivemind_connection;
 
-window.onConnect = () => {
-    console.log("connecting to HiveMind")
-    let ip = document.getElementById("hmip").value
-    let port = document.getElementById("hmport").value
-    let key = document.getElementById("hmkey").value
-    // The password is all that is normally needed: against a v3 hivemind-core instance HiveMind-js
-    // derives the Noise PSK as argon2id(password, SHA-256(node_id)) in-browser via
-    // @noble and negotiates the default ChaChaPoly suite (full parity with
-    // hivemind-core); on the legacy v1 path it drives the PBKDF2-HMAC-SHA256
-    // handshake + AES-GCM session key.
-    let password = document.getElementById("hmpassword").value
-    let user = "HivemindWebSpeechV0.2"
-
-    // Optional protocol-v3 (Noise) options. Empty fields leave the client on the
-    // password path (argon2id PSK in-browser, or legacy v1 fallback).
-    let options = {}
-    let psk = (document.getElementById("hmpsk").value || "").trim()
-    if (psk) options.psk = psk
-    let serverKey = (document.getElementById("hmserverkey").value || "").trim()
-    if (serverKey) options.serverNoiseKey = serverKey
-
-    hivemind_connection.connect(ip, port, user, key, password, options);
-
-    window.toggleVAD()
-    getToggleButton().disabled = false
-    getToggleButton().classList.remove("is-loading")
+// ── Binary audio transport (WIRE-1 STT_AUDIO_HANDLE frames) ───────────────────
+// HiveMind-js has no convenience method for raw-audio binary frames, so this
+// builds and sends one directly: the same bitstring codec the client uses, then
+// its own encrypted-send path (Noise transport for v3, AES-GCM binary for v1).
+function canSendBinary(conn) {
+  return !!(conn._noiseTransport || conn._binarize);
 }
 
-async function main() {
-
-  try {
-
-    const myvad = await vad.MicVAD.new({
-
-      onSpeechStart: () => {
-        console.log("Speech start")
-      },
-
-      onSpeechEnd: (arr) => {
-        console.log("Speech end")
-        const wavBuffer = vad.utils.encodeWAV(arr)
-        console.log(arr)
-        console.log(wavBuffer)
-        const base64 = vad.utils.arrayBufferToBase64(wavBuffer)
-        const url = `data:audio/wav;base64,${base64}`
-        const el = addAudio(url)
-        const speechList = document.getElementById("audio-list")
-        speechList.prepend(el)
-
-        window.hivemind_connection.sendAudioB64(base64)
-
-      },
-    })
-
-    window.myvad = myvad
-
-
-    window.toggleVAD = () => {
-      console.log("ran toggle vad")
-      if (myvad.listening === false) {
-        myvad.start()
-        getToggleButton().textContent = "Stop VAD"
-      } else {
-        myvad.pause()
-        getToggleButton().textContent = "Start VAD"
-      }
-    }
-  } catch (e) {
-    console.error("Failed:", e)
+async function sendAudioBinary(conn, pcmBytes, meta) {
+  const frame = encodeAudioBinaryFrame(
+    globalThis.encodeBitstring,
+    globalThis.BIN_TYPES,
+    pcmBytes,
+    meta
+  );
+  if (conn._noiseTransport) {
+    const v3frame = await conn._noiseTransport.encryptFrame(frame);
+    conn.ws.send(v3frame.buffer);
+  } else {
+    await conn._sendEncryptedBinary(frame);
   }
+}
+
+// ── Wake word (precise-onnx-js), loaded on demand ─────────────────────────────
+let _preciseLoaded = null;
+function loadScriptOnce(url) {
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = url;
+    s.onload = resolve;
+    s.onerror = () => reject(new Error('failed to load ' + url));
+    document.head.appendChild(s);
+  });
+}
+
+async function ensurePrecise() {
+  if (!_preciseLoaded) {
+    _preciseLoaded = (async () => {
+      // mfcc.js must load before wakeword.js; both need globalThis.ort (already
+      // present — onnxruntime-web is loaded for the VAD).
+      await loadScriptOnce(PRECISE_MFCC_URL);
+      await loadScriptOnce(PRECISE_WW_URL);
+      return globalThis.PreciseOnnxWakeWord;
+    })();
+  }
+  return _preciseLoaded;
+}
+
+let _wakeDetector = null;
+async function getWakeDetector() {
+  if (!_wakeDetector) {
+    const PreciseOnnxWakeWord = await ensurePrecise();
+    _wakeDetector = await PreciseOnnxWakeWord.load(config.preciseModelUrl);
+  }
+  return _wakeDetector;
+}
+
+const captureGate = new CaptureGate(config.wakeWord, async (float32) => {
+  const detector = await getWakeDetector();
+  return detectWakeWordInUtterance(detector, float32);
+});
+
+// ── TTS (phoonnx.js), loaded on demand ────────────────────────────────────────
+let _phoonnx = null;
+async function ensurePhoonnx() {
+  if (!_phoonnx) {
+    _phoonnx = (async () => {
+      const [mod, voicesMod] = await Promise.all([
+        import(/* @vite-ignore */ PHOONNX_ESM_URL),
+        import(/* @vite-ignore */ PHOONNX_VOICES_ESM_URL),
+      ]);
+      return { mod, voicesMod, voice: null };
+    })();
+  }
+  return _phoonnx;
+}
+
+async function speakWithPhoonnx(text) {
+  const p = await ensurePhoonnx();
+  if (!p.voice) {
+    const entry = p.voicesMod.getVoice(config.phoonnxVoice);
+    if (!entry) throw new Error('unknown phoonnx voice: ' + config.phoonnxVoice);
+    p.voice = await p.mod.loadVoice(entry);
+  }
+  const blob = await p.mod.synthesizeWav(p.voice, text);
+  const audio = new Audio(URL.createObjectURL(blob));
+  await audio.play();
+}
+
+// ── Connect ───────────────────────────────────────────────────────────────────
+window.onConnect = () => {
+  console.log('connecting to HiveMind');
+  const ip = document.getElementById('hmip').value;
+  const port = document.getElementById('hmport').value;
+  const key = document.getElementById('hmkey').value;
+  // The password alone is normally enough: against a v3 hivemind-core instance
+  // HiveMind-js derives the Noise PSK as argon2id(password, SHA-256(node_id))
+  // in-browser and negotiates the default ChaChaPoly suite; on the legacy v1
+  // path it drives the PBKDF2-HMAC-SHA256 handshake + AES-GCM session key.
+  const password = document.getElementById('hmpassword').value;
+  const user = 'HivemindWebSpeechV0.2';
+
+  const options = {};
+  const psk = (document.getElementById('hmpsk').value || '').trim();
+  if (psk) options.psk = psk;
+  const serverKey = (document.getElementById('hmserverkey').value || '').trim();
+  if (serverKey) options.serverNoiseKey = serverKey;
+
+  hivemind_connection.connect(ip, port, user, key, password, options);
+
+  window.toggleVAD();
+  getToggleButton().disabled = false;
+  getToggleButton().classList.remove('is-loading');
+};
+
+// ── Settings panel ────────────────────────────────────────────────────────────
+function applyConfigToForm() {
+  const set = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.value = value;
+  };
+  set('cfgWakeWord', config.wakeWord);
+  set('cfgTransport', config.transport);
+  set('cfgTts', config.tts);
+  set('cfgPreciseModel', config.preciseModelUrl);
+  set('cfgPhoonnxVoice', config.phoonnxVoice);
+}
+
+function readConfigFromForm() {
+  const val = (id, fallback) => {
+    const el = document.getElementById(id);
+    return el ? el.value : fallback;
+  };
+  return {
+    wakeWord: val('cfgWakeWord', config.wakeWord),
+    transport: val('cfgTransport', config.transport),
+    tts: val('cfgTts', config.tts),
+    preciseModelUrl: val('cfgPreciseModel', config.preciseModelUrl),
+    phoonnxVoice: val('cfgPhoonnxVoice', config.phoonnxVoice),
+  };
+}
+
+window.onSaveSettings = () => {
+  config = saveConfig(globalThis.localStorage, readConfigFromForm());
+  // Re-target the pieces that hold state from the previous config.
+  captureGate.mode = config.wakeWord;
+  captureGate.reset();
+  _wakeDetector = null; // reload if the model URL changed
+  if (_phoonnx) _phoonnx = null; // reload if the voice changed
+  applyConfigToForm();
+  logLine('Settings saved.');
+};
+
+// ── Microphone + VAD ──────────────────────────────────────────────────────────
+async function main() {
+  applyConfigToForm();
 
   function addAudio(audioUrl) {
-    const entry = document.createElement("li")
-    const audio = document.createElement("audio")
-    audio.controls = true
-    audio.src = audioUrl
-    entry.appendChild(audio)
-    return entry
+    const entry = document.createElement('li');
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.src = audioUrl;
+    entry.appendChild(audio);
+    return entry;
+  }
+
+  async function handleUtterance(arr) {
+    const decision = await captureGate.consider(arr);
+    if (!decision.send) {
+      if (decision.armed) logLine('Wake word detected — listening…');
+      return;
+    }
+
+    const wavBuffer = vad.utils.encodeWAV(arr);
+    const base64 = vad.utils.arrayBufferToBase64(wavBuffer);
+    const url = `data:audio/wav;base64,${base64}`;
+    document.getElementById('audio-list').prepend(addAudio(url));
+
+    try {
+      if (config.transport === 'binary' && canSendBinary(hivemind_connection)) {
+        const pcm = floatTo16BitPCM(arr);
+        await sendAudioBinary(hivemind_connection, pcm, { sample_rate: 16000, sample_width: 2 });
+      } else {
+        if (config.transport === 'binary') {
+          console.warn('binary transport not negotiated; using base64');
+        }
+        await hivemind_connection.sendAudioB64(base64);
+      }
+    } catch (e) {
+      console.error('failed to send audio:', e);
+    }
+  }
+
+  try {
+    const myvad = await vad.MicVAD.new({
+      onSpeechStart: () => console.log('Speech start'),
+      onSpeechEnd: (arr) => {
+        console.log('Speech end');
+        handleUtterance(arr).catch((e) => console.error(e));
+      },
+    });
+
+    window.myvad = myvad;
+
+    window.toggleVAD = () => {
+      if (myvad.listening === false) {
+        myvad.start();
+        getToggleButton().textContent = 'Stop VAD';
+      } else {
+        myvad.pause();
+        getToggleButton().textContent = 'Start VAD';
+      }
+    };
+  } catch (e) {
+    console.error('Failed:', e);
   }
 }
 
-main()
+// Guard the DOM bootstrap so the module can be imported headlessly in tests.
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  // Exposed for reference / debugging.
+  window.WAKE_WORD_MODES = WAKE_WORD_MODES;
+  window.TRANSPORT_MODES = TRANSPORT_MODES;
+  window.TTS_MODES = TTS_MODES;
+  main();
+}

--- a/tests/binary_transport.test.mjs
+++ b/tests/binary_transport.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Binary-transport interop test. The 'binary' audio option builds a WIRE-1
+ * bin frame with the real HiveMind-js codec; this asserts the exact frame the
+ * page emits round-trips back through the client's decoder as a STT_AUDIO_HANDLE
+ * binary message carrying the original PCM bytes and the sample-rate/width
+ * metadata hivemind-core reads. It self-skips when HiveMind-js is not resolvable.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+import { floatTo16BitPCM, encodeAudioBinaryFrame } from '../src/audio.js';
+import { BIN_TYPES_FALLBACK } from '../src/constants.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+function resolveHivemindJs() {
+  if (process.env.HIVEMIND_JS_PATH) return resolve(process.env.HIVEMIND_JS_PATH);
+  try {
+    return require.resolve('hivemind-js');
+  } catch {
+    const sibling = resolve(__dirname, '..', '..', 'HiveMind-js', 'static', 'js', 'hivemind.js');
+    if (existsSync(sibling)) return sibling;
+    return null;
+  }
+}
+
+const hmPath = resolveHivemindJs();
+
+test('binary audio frame round-trips through the HiveMind-js WIRE-1 codec', { skip: !hmPath ? 'HiveMind-js not found (set HIVEMIND_JS_PATH)' : false }, async () => {
+  const hm = require(hmPath);
+  const { encodeBitstring, decodeBitstring, BIN_TYPES } = hm;
+
+  const samples = new Float32Array([0.25, -0.25, 0.5, -0.5]);
+  const pcm = floatTo16BitPCM(samples);
+
+  const frame = encodeAudioBinaryFrame(encodeBitstring, BIN_TYPES, pcm, { lang: 'en-us' });
+  const decoded = await decodeBitstring(frame);
+
+  assert.equal(decoded.msgType, 'bin');
+  assert.equal(decoded.binType, (BIN_TYPES || BIN_TYPES_FALLBACK).STT_AUDIO_HANDLE);
+  assert.equal(decoded.metadata.sample_rate, 16000);
+  assert.equal(decoded.metadata.sample_width, 2);
+  assert.equal(decoded.metadata.lang, 'en-us');
+  assert.deepEqual([...new Uint8Array(decoded.payload)], [...pcm]);
+});

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * Config plumbing + capture-routing unit tests. These are DOM-free and
+ * network-free: they exercise the persisted settings model (src/config.js) and
+ * the audio helpers / capture gate (src/audio.js) that decide, per option, how
+ * the page behaves. Browser-only pieces (the wake-word model, the phoonnx voice,
+ * the live socket) are stubbed.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULTS,
+  WAKE_WORD_MODES,
+  TRANSPORT_MODES,
+  TTS_MODES,
+  normalizeConfig,
+  loadConfig,
+  saveConfig,
+  STORAGE_KEY,
+} from '../src/config.js';
+
+import {
+  floatTo16BitPCM,
+  encodeAudioBinaryFrame,
+  CaptureGate,
+  detectWakeWordInUtterance,
+} from '../src/audio.js';
+
+import { BIN_TYPES_FALLBACK } from '../src/constants.js';
+
+// A minimal localStorage-like backend.
+function memStorage(initial) {
+  const map = new Map(Object.entries(initial || {}));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    _map: map,
+  };
+}
+
+// ── defaults ──────────────────────────────────────────────────────────────────
+
+test('defaults preserve the original behaviour on every axis', () => {
+  assert.equal(DEFAULTS.wakeWord, 'off');
+  assert.equal(DEFAULTS.transport, 'base64');
+  assert.equal(DEFAULTS.tts, 'server-text');
+});
+
+test('loadConfig returns the defaults when storage is empty or missing', () => {
+  assert.deepEqual(loadConfig(memStorage()), normalizeConfig());
+  assert.deepEqual(loadConfig(null), normalizeConfig());
+  assert.deepEqual(loadConfig(memStorage({ [STORAGE_KEY]: '{ not json' })), normalizeConfig());
+});
+
+// ── normalization / hardening ─────────────────────────────────────────────────
+
+test('normalizeConfig rejects unknown enum values and falls back to defaults', () => {
+  const c = normalizeConfig({ wakeWord: 'bogus', transport: 'udp', tts: 42 });
+  assert.equal(c.wakeWord, 'off');
+  assert.equal(c.transport, 'base64');
+  assert.equal(c.tts, 'server-text');
+});
+
+test('normalizeConfig accepts every valid enum value', () => {
+  for (const w of WAKE_WORD_MODES) assert.equal(normalizeConfig({ wakeWord: w }).wakeWord, w);
+  for (const t of TRANSPORT_MODES) assert.equal(normalizeConfig({ transport: t }).transport, t);
+  for (const t of TTS_MODES) assert.equal(normalizeConfig({ tts: t }).tts, t);
+});
+
+test('blank string fields fall back to defaults', () => {
+  const c = normalizeConfig({ preciseModelUrl: '   ', phoonnxVoice: '' });
+  assert.equal(c.preciseModelUrl, DEFAULTS.preciseModelUrl);
+  assert.equal(c.phoonnxVoice, DEFAULTS.phoonnxVoice);
+});
+
+// ── round-trip ────────────────────────────────────────────────────────────────
+
+test('saveConfig then loadConfig round-trips a full non-default config', () => {
+  const storage = memStorage();
+  const written = saveConfig(storage, {
+    wakeWord: 'precise-onnx-js',
+    transport: 'binary',
+    tts: 'phoonnx-js',
+    preciseModelUrl: 'https://example/ww.onnx',
+    phoonnxVoice: 'phoonnx_eu-ES_dii_unicode',
+  });
+  const read = loadConfig(storage);
+  assert.deepEqual(read, written);
+  assert.equal(read.transport, 'binary');
+  assert.equal(read.wakeWord, 'precise-onnx-js');
+  assert.equal(read.tts, 'phoonnx-js');
+});
+
+// ── binary transport encoding ─────────────────────────────────────────────────
+
+test('floatTo16BitPCM produces little-endian 16-bit samples clamped to range', () => {
+  const pcm = floatTo16BitPCM(new Float32Array([0, 1, -1, 2, -2]));
+  assert.equal(pcm.length, 10);
+  const view = new DataView(pcm.buffer);
+  assert.equal(view.getInt16(0, true), 0);
+  assert.equal(view.getInt16(2, true), 0x7fff); // +1 full scale
+  assert.equal(view.getInt16(4, true), -0x8000); // -1 full scale
+  assert.equal(view.getInt16(6, true), 0x7fff); // +2 clamped
+  assert.equal(view.getInt16(8, true), -0x8000); // -2 clamped
+});
+
+test('encodeAudioBinaryFrame builds a STT_AUDIO_HANDLE bin frame the client can decode', () => {
+  // Use the real HiveMind-js codec if available; otherwise assert the fallback
+  // bin-type wiring (the frame is opaque without the decoder).
+  const captured = {};
+  const fakeEncode = (msgType, payload, metadata, binType) => {
+    Object.assign(captured, { msgType, payload, metadata, binType });
+    return new Uint8Array([1, 2, 3]);
+  };
+  const pcm = floatTo16BitPCM(new Float32Array([0.5, -0.5]));
+  const frame = encodeAudioBinaryFrame(fakeEncode, BIN_TYPES_FALLBACK, pcm, { lang: 'en-us' });
+  assert.deepEqual([...frame], [1, 2, 3]);
+  assert.equal(captured.msgType, 'bin');
+  assert.equal(captured.binType, BIN_TYPES_FALLBACK.STT_AUDIO_HANDLE);
+  assert.equal(captured.payload, pcm);
+  assert.equal(captured.metadata.sample_rate, 16000);
+  assert.equal(captured.metadata.sample_width, 2);
+  assert.equal(captured.metadata.lang, 'en-us');
+});
+
+// ── wake-word capture gate ────────────────────────────────────────────────────
+
+test("wake word 'off' streams every utterance", async () => {
+  const gate = new CaptureGate('off', async () => true);
+  for (let i = 0; i < 3; i++) {
+    const d = await gate.consider(new Float32Array(4));
+    assert.equal(d.send, true);
+  }
+});
+
+test('precise gate swallows the wake-word utterance then streams the next one', async () => {
+  let fire = false;
+  const gate = new CaptureGate('precise-onnx-js', async () => fire);
+
+  // No wake word yet — nothing is streamed.
+  assert.deepEqual(await gate.consider(new Float32Array(4)), { send: false, armed: false });
+
+  // Wake word fires: this utterance is swallowed, the gate arms.
+  fire = true;
+  assert.deepEqual(await gate.consider(new Float32Array(4)), { send: false, armed: true });
+
+  // Next utterance (the command) streams; the gate disarms.
+  fire = false;
+  assert.deepEqual(await gate.consider(new Float32Array(4)), { send: true, armed: false });
+
+  // And we are back to requiring the wake word again.
+  assert.deepEqual(await gate.consider(new Float32Array(4)), { send: false, armed: false });
+});
+
+test('a detector error is treated as no-detection (fail safe, stays disarmed)', async () => {
+  const gate = new CaptureGate('precise-onnx-js', async () => {
+    throw new Error('model blew up');
+  });
+  assert.deepEqual(await gate.consider(new Float32Array(4)), { send: false, armed: false });
+});
+
+test('detectWakeWordInUtterance feeds fixed chunks and reports any activation', async () => {
+  const chunks = [];
+  const detector = {
+    clear() {},
+    async predict(chunk) {
+      chunks.push(chunk.length);
+      return chunk[0] === 9; // fire on the marked chunk only
+    },
+  };
+  const utt = new Float32Array(5000); // 3 chunks of 2048 (last padded)
+  utt[2048] = 9; // mark the start of the 2nd chunk
+  const fired = await detectWakeWordInUtterance(detector, utt, 2048);
+  assert.equal(fired, true);
+  assert.deepEqual(chunks, [2048, 2048, 2048]); // last chunk zero-padded to size
+});

--- a/tests/v3_negotiation.test.mjs
+++ b/tests/v3_negotiation.test.mjs
@@ -42,6 +42,13 @@ function resolveHivemindJs() {
 const hm = require(resolveHivemindJs());
 const { JarbasHiveMind, selectNoiseOptions, derivePskPBKDF2, NOISE_SUITES_JS } = hm;
 
+// The client advertises ChaCha20-Poly1305 only when its @noble backend is
+// present; a minimal Web-Crypto-only bundle is AES-GCM only. These assertions
+// adapt to whichever suites the loaded client can actually run.
+const CHACHA = '25519_ChaChaPoly_SHA256';
+const AESGCM = '25519_AESGCM_SHA256';
+const CAN_CHACHA = NOISE_SUITES_JS.indexOf(CHACHA) !== -1;
+
 const NODE_ID = 'HiveMind-Node';
 const PASSWORD = 'super secret hive password';
 
@@ -59,20 +66,30 @@ function pbkdf2Hello() {
     };
 }
 
-test('selectNoiseOptions picks the AES-GCM suite the browser can run', () => {
+test('selectNoiseOptions picks the client-preferred suite both peers support', () => {
     const sel = selectNoiseOptions(
         ['XXpsk2', 'KKpsk0'],
-        ['25519_ChaChaPoly_SHA256', '25519_AESGCM_SHA256'],
+        [CHACHA, AESGCM],
         null);
     assert.ok(sel, 'a mutual pattern/suite must be selected');
-    assert.equal(sel.suite, '25519_AESGCM_SHA256');
+    // The client walks its own preference order, so the winner is the first
+    // entry of NOISE_SUITES_JS the server also offers.
+    assert.equal(sel.suite, NOISE_SUITES_JS[0]);
     assert.equal(sel.pattern, 'XXpsk2');
-    assert.deepEqual(NOISE_SUITES_JS, ['25519_AESGCM_SHA256']);
+    // AES-GCM is always runnable in a browser (Web Crypto); it must be offered.
+    assert.ok(NOISE_SUITES_JS.indexOf(AESGCM) !== -1);
 });
 
-test('selectNoiseOptions declines a ChaChaPoly-only server', () => {
-    const sel = selectNoiseOptions(['XXpsk2'], ['25519_ChaChaPoly_SHA256'], null);
-    assert.equal(sel, null);
+test('selectNoiseOptions and a ChaChaPoly-only server', () => {
+    const sel = selectNoiseOptions(['XXpsk2'], [CHACHA], null);
+    if (CAN_CHACHA) {
+        // A ChaCha-capable client interoperates over the default suite.
+        assert.ok(sel);
+        assert.equal(sel.suite, CHACHA);
+    } else {
+        // A Web-Crypto-only client cannot run ChaCha -> legacy handshake.
+        assert.equal(sel, null);
+    }
 });
 
 test('password derives a valid v3 PSK against a PBKDF2-KDF hub', async () => {
@@ -90,16 +107,24 @@ test('password derives a valid v3 PSK against a PBKDF2-KDF hub', async () => {
     assert.deepEqual([...psk], [...expected]);
 });
 
-test('argon2id hub with no provisioned PSK falls back to legacy (null)', async () => {
+test('argon2id hub with no provisioned PSK derives (or declines) per client capability', async () => {
     const c = new JarbasHiveMind();
     c._maxProtocolVersion = 3;
     c._password = PASSWORD;
     c._serverNodeId = NODE_ID;
 
     const hello = pbkdf2Hello();
-    hello.noise.kdf = { name: 'argon2id' };   // Web Crypto cannot compute this
+    hello.noise.kdf = { name: 'argon2id' };   // the server default KDF
     const psk = await c._resolveNoisePsk(hello);
-    assert.equal(psk, null, 'must decline v3 and fall back to legacy');
+    if (CAN_CHACHA) {
+        // An @noble-backed client computes argon2id in-browser (full parity),
+        // so the password alone yields a valid 32-byte PSK.
+        assert.ok(psk instanceof Uint8Array);
+        assert.equal(psk.length, 32);
+    } else {
+        // A Web-Crypto-only client cannot compute argon2id -> legacy fallback.
+        assert.equal(psk, null);
+    }
 });
 
 test('a provisioned PSK is honoured regardless of server KDF', async () => {


### PR DESCRIPTION
## Summary

Makes the browser voice satellite configurable across three independent axes via a **Settings** panel persisted in `localStorage`. Every option defaults to the current behaviour, so an untouched page is unchanged and nothing regresses.

| Axis | Default | Alternative |
|---|---|---|
| **Wake word** | `off` (VAD / push-to-talk) | `precise-onnx-js` — loads a Precise ONNX model in-browser and gates capture until the wake word fires |
| **Audio transport** | `base64` (`recognizer_loop:b64_audio`) | `binary` — sends each utterance as a WIRE-1 `STT_AUDIO_HANDLE` raw-PCM frame; auto-falls back to base64 when the session cannot carry binary frames |
| **TTS** | `server-text` (reply shown as text) | `phoonnx-js` — synthesizes the reply in-browser with phoonnx.js and plays it, with a voice selector |

## How each mode works

- **Wake word** — VAD still segments utterances; while the gate is disarmed each utterance is fed to a [precise-onnx-js](https://github.com/TigreGotico/precise-onnx-js) `PreciseOnnxWakeWord` in 2048-sample chunks. When it fires, that utterance is swallowed and the gate arms; the next utterance (the command) is streamed, then the gate disarms.
- **Binary transport** — normalized VAD float PCM is converted to 16-bit LE PCM and wrapped in a HiveMind-js WIRE-1 `bin` frame (`STT_AUDIO_HANDLE`, `sample_rate`/`sample_width` metadata), then sent through the client's own encrypted path (Noise transport for v3, AES-GCM binary for v1). HiveMind-js has no raw-audio binary convenience method, so this builds the frame directly with its exposed codec.
- **TTS** — the `speak` reply is always shown as text; with `phoonnx-js` the text is additionally synthesized and played via [phoonnx.js](https://github.com/TigreGotico/phoonnx.js).

The wake-word and TTS libraries load lazily, only when their mode is enabled — the default page fetches nothing extra. Wake-word models are referenced by URL (a hosted `hey_mycroft` model by default) and phoonnx voices by id; no weights are committed.

## Structure

DOM-free logic (settings model, PCM encoding, capture gating) lives in `src/config.js` and `src/audio.js` so it is unit testable; `src/index.js` wires it to the page, mic, and HiveMind-js client.

## Testing

- `tests/config.test.mjs` — config defaults/normalization/hardening/round-trip, PCM encoding, the wake-word capture gate state machine, and chunked detection. 13 cases.
- `tests/binary_transport.test.mjs` — the exact binary frame the page emits round-trips back through the real HiveMind-js WIRE-1 codec as a `STT_AUDIO_HANDLE` message carrying the original PCM and metadata.
- All 19 non-e2e tests pass locally (`node --test`).
- **Smoke-tested vs live:** the config plumbing, PCM/frame encoding, and gating are fully tested headless. The precise-onnx-js and phoonnx.js runtime loads and the binary send over a live socket need a real mic + models + a running hivemind-core and were not exercised end to end here.

The `test:` commit adapts the pre-existing v3 negotiation assertions to HiveMind-js's now-merged ChaCha20-Poly1305 + argon2id browser parity (they hard-coded the old AES-GCM-only reality).

## Note

Branched on the protocol-v3 (Noise) branch (#13); rebase onto `dev` once #13 lands. The added feature commits are the last two on the branch.

> Pre-release software — expect bugs and breaking changes.
